### PR TITLE
Profile screen now refreshes on weight update

### DIFF
--- a/Nutriq/ViewControllers/HOME-ViewControllers/PROFILE - ViewControllers/ProfileViewController.swift
+++ b/Nutriq/ViewControllers/HOME-ViewControllers/PROFILE - ViewControllers/ProfileViewController.swift
@@ -9,6 +9,9 @@
 import UIKit
 import Firebase
 
+// Instantiate the ProfileViewController to allow for its functions to be called outside of itself; More specifically, the 'loadUserData' function which will update the profile screen with the most current stats after the user updates their weight
+var profileVCInstance = ProfileViewController()
+
 class ProfileViewController: UIViewController {
     
     
@@ -41,6 +44,7 @@ class ProfileViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        profileVCInstance = self
         
         self.title = "Profile"
         
@@ -61,6 +65,7 @@ class ProfileViewController: UIViewController {
         goalsView.layer.cornerRadius = 5.0
         maintenanceCaloriesView.layer.cornerRadius = 5.0
         goalCaloriesView.layer.cornerRadius = 5.0
+        
         
         
     }
@@ -149,6 +154,5 @@ class ProfileViewController: UIViewController {
         updateWeightVC.didMove(toParent: self)
         
     }
-
-
 }
+

--- a/Nutriq/ViewControllers/HOME-ViewControllers/PROFILE - ViewControllers/UpdateWeightViewController.swift
+++ b/Nutriq/ViewControllers/HOME-ViewControllers/PROFILE - ViewControllers/UpdateWeightViewController.swift
@@ -65,7 +65,7 @@ class UpdateWeightViewController: UIViewController {
         // User input validation passed; Send the current weight for storage in the Firebase Database
         recalculateGoalStats(currentWeight)
         print("Completed recalculating goal stats. Closing update weight popup view...\n")
-        self.closePopupView()
+        self.closePopupViewAnimated()
 
     }
     
@@ -113,6 +113,8 @@ class UpdateWeightViewController: UIViewController {
             let goalCalories = self.maintenanceCalories + Int(round(weeklyGoal * 500))
             print("Your daily caloric GOAL needs are:", goalCalories)
             
+            
+            
             self.storeUserHealthStats(age, self.maintenanceCalories, goalCalories, currentWeight, weightLeftUntilGoal)
         }
     }
@@ -154,7 +156,6 @@ class UpdateWeightViewController: UIViewController {
         }
     }
     
-    // Close animation for "Update Weight" popup
     func closePopupView() {
         UIView.animate(withDuration: 0.2, animations: {
             self.view.transform = CGAffineTransform(scaleX: 1.3, y: 1.3)
@@ -166,4 +167,22 @@ class UpdateWeightViewController: UIViewController {
         }
     }
     
+    // Close animation for "Update Weight" popup
+    func closePopupViewAnimated() {
+        UIView.animate(withDuration: 0.2, animations: {
+            self.view.transform = CGAffineTransform(scaleX: 1.3, y: 1.3)
+            self.view.alpha = 0.0
+        }) { (finished: Bool) in
+            if finished {
+                self.view.removeFromSuperview()
+                
+                // Update the changed values on the profile screen
+                profileVCInstance.currentWeightLabel.alpha = 0
+//                profileVCInstance.motivationalMessageLabel.alpha = 0
+                profileVCInstance.maintenanceCaloriesLabel.alpha = 0
+                profileVCInstance.goalCaloriesLabel.alpha = 0
+                profileVCInstance.getAndLoadUserData()
+            }
+        }
+    }
 }


### PR DESCRIPTION
- Added animated closing popupView function to UpdateWeightViewController

If user updates their current weight, values that were changed because
of the new weight refresh and fade out/in again. If the user cancels
updating their current weight, nothing animates and the popupView closes.